### PR TITLE
add viewport meta tag to popup.pug

### DIFF
--- a/src/views/popup.pug
+++ b/src/views/popup.pug
@@ -3,6 +3,7 @@ html
 	head
 		title Dissenter
 		meta(charset="utf-8")
+		meta(name='viewport' content='width=device-width, initial-scale=1')
 		link(href='./popup.css' type='text/css' rel='stylesheet')
 	body
 		div(class='popup')


### PR DESCRIPTION
While dissenter currently works in Firefox for Android the scaling is off, which this change should fix.