### PR TITLE
Add Dissenter Comment Section To Every YouTube Video

### DIFF
--- a/src/scripts/content/youtube/script.js
+++ b/src/scripts/content/youtube/script.js
@@ -105,52 +105,62 @@ var GDYoutube = function() {
         });
     };
 
+    // todo: possibly setup a utils folder for browser-side functions
+    // remove element from dom
+    Element.prototype.remove = function() {
+        this.parentElement.removeChild(this);
+    };
+
+    // add element to dom before given element
+    Element.prototype.appendBefore = function (element) {
+        element.parentNode.insertBefore(this, element);
+    }, false;
+
+
+  // add element to dom after given element
+    Element.prototype.appendAfter = function(element) {
+        element.parentNode.insertBefore(this, element.nextSibling);
+    }, false;
+
     /**
     * @description - Adds a Dissenter comment section to the bottom of every YouTube video
     * @function addCommentSection
     */
     function addCommentSection(){
 
-        Element.prototype.remove = function() {
-          this.parentElement.removeChild(this);
-        };
-
+        // check if a comment iframe already exists
         var alreadyExistingElement = document.getElementsByClassName('existing-iframe')
 
+        // delete the comment iframe if it already exists
         if(alreadyExistingElement && alreadyExistingElement[0]){
           alreadyExistingElement[0].remove();
         }
 
+        // dissenter address to append current url to
         var BASE_URI = 'https://dissenter.com/discussion/begin-extension?url=';
 
+        // current browser url
         var url = window.location.href;
+
+        // url encode current url
         var encoded = encodeURIComponent(url);
 
+        // build url encoded link to dissenter
         var commentUrl = BASE_URI + encoded;
-        console.log(commentUrl);
 
-          /* Typical Creation and Setup A New Orphaned Element Object */
-        var NewElement = document.createElement('iframe');
-        NewElement.src = commentUrl;
-        NewElement.className = 'popup__iframe abs existing-iframe';
-        NewElement.id = 'popup-iframe';
-        NewElement.style.height = '500px';
-        NewElement.style.width = '100%';
+        // create a new iframe
+        var commentsIframe = document.createElement('iframe');
+        commentsIframe.src = commentUrl;
+        commentsIframe.className = 'popup__iframe abs existing-iframe';
+        commentsIframe.id = 'popup-iframe';
+        commentsIframe.style.height = '500px';
+        commentsIframe.style.width = '100%';
 
+        // div to stick iframe in after, currently start of youtube comments
         var youtubeCommentsDiv = document.getElementsByTagName("ytd-comments")
 
-        Element.prototype.appendBefore = function (element) {
-          element.parentNode.insertBefore(this, element);
-        },false;
-
-
-          /* Adds Element AFTER NeighborElement */
-        Element.prototype.appendAfter = function(element) {
-          element.parentNode.insertBefore(this, element.nextSibling);
-        }, false;
-
-          /* Add NewElement BEFORE -OR- AFTER Using the Aforementioned Prototypes */
-        NewElement.appendBefore(youtubeCommentsDiv[0]);
+        /* Add NewElement BEFORE -OR- AFTER Using the Aforementioned Prototypes */
+        commentsIframe.appendBefore(youtubeCommentsDiv[0]);
     }
 
     //Global functions

--- a/src/scripts/content/youtube/script.js
+++ b/src/scripts/content/youtube/script.js
@@ -105,9 +105,55 @@ var GDYoutube = function() {
         });
     };
 
+    /**
+    * @description - Adds a Dissenter comment section to the bottom of every YouTube video
+    * @function addCommentSection
+    */
+    function addCommentSection(){
+
+        Element.prototype.remove = function() {
+          this.parentElement.removeChild(this);
+        };
+
+        var alreadyExistingElement = document.getElementsByClassName('existing-iframe')
+
+        if(alreadyExistingElement && alreadyExistingElement[0]){
+          alreadyExistingElement[0].remove();
+        }
+
+        var BASE_URI = 'https://dissenter.com/discussion/begin-extension?url=';
+
+        var url = window.location.href;
+        var encoded = encodeURIComponent(url);
+
+        var commentUrl = BASE_URI + encoded;
+        console.log(commentUrl);
+
+          /* Typical Creation and Setup A New Orphaned Element Object */
+        var NewElement = document.createElement('iframe');
+        NewElement.src = commentUrl;
+        NewElement.className = 'popup__iframe abs existing-iframe';
+        NewElement.id = 'popup-iframe';
+        NewElement.style.height = '500px';
+        NewElement.style.width = '100%';
+
+        var youtubeCommentsDiv = document.getElementsByTagName("ytd-comments")
+
+        Element.prototype.appendBefore = function (element) {
+          element.parentNode.insertBefore(this, element);
+        },false;
+
+
+          /* Adds Element AFTER NeighborElement */
+        Element.prototype.appendAfter = function(element) {
+          element.parentNode.insertBefore(this, element.nextSibling);
+        }, false;
+
+          /* Add NewElement BEFORE -OR- AFTER Using the Aforementioned Prototypes */
+        NewElement.appendBefore(youtubeCommentsDiv[0]);
+    }
 
     //Global functions
-
 
     /**
      * @description - Init script on open
@@ -115,6 +161,11 @@ var GDYoutube = function() {
      */
     scope.init = function() {
         fetchElements();
+
+        // add a comment section to every youtube video
+        addCommentSection();
+        window.addEventListener("spfdone", addCommentSection); // old youtube design
+        window.addEventListener("yt-navigate-start", addCommentSection); // new youtube design
     };
 };
 


### PR DESCRIPTION
This feature was written to allow comments on unrestricted and comments disabled videos, has to be polished up a little bit and should probably have options added to be able to disable the feature and select which types of videos it should display under, but it's a very useful feature.

Also getting 403 errors from the backend occasionally, don't know if that's from the implementation or a bug. Would like to work with a backend developer to straighten that out.

![Screen Shot 2019-05-23 at 1 59 22 PM](https://user-images.githubusercontent.com/50925833/58282452-045dc800-7d63-11e9-9c79-336a963012c7.png)
This is how limited state videos work now with the dropped in comment section. Pretty snazzy.