### PR TITLE
Fixes bug where spinner blocked logins on Edge & Updates Download Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For more information, please visit: https://dissenter.com
 
 # • Download the Dissenter Browser Extension
 
-Please head over to https://dissenter.com/download to download the extension for your specific browser and view detailed installation instructions.
+Please visit https://github.com/gab-ai-inc/gab-dissenter-extension/releases to download the extension for your specific browser.
 
 # • Installation
 

--- a/config/browsers.js
+++ b/config/browsers.js
@@ -63,7 +63,7 @@ const edge = new Browser({
     slug: 'edge',
     version: '0.1.8',
     scriptVariableMap: {
-        BROWSER: 'browser',
+        BROWSER: 'chrome',
         MESSENGER: 'runtime',
     },
     manifestMap: {


### PR DESCRIPTION
Addresses an issue as part of Issue https://github.com/gab-ai-inc/gab-dissenter-extension/issues/7#issuecomment-780202198 where spinner is perpetually displayed due to an error.

Change addresses the spinner issue by replacing "browser" with "chrome" as discussed here: https://stackoverflow.com/questions/63825136/ms-edge-api-error-browser-is-not-defined

Changed value on Edge (Chromium) Version 90.0.789.1 (Official build) dev (64-bit) where I have Dissenter plugin installed and it addressed the issue with hanging on the spinner pop-up.

It also updates the Download link.